### PR TITLE
Sauvegarde de ThresholdDisplay dans le localStorage

### DIFF
--- a/frontend/src/app/constants/constants.ts
+++ b/frontend/src/app/constants/constants.ts
@@ -134,6 +134,7 @@ export const SENSOR_VALIDITY_CLASSES = {
 
 export const LOCAL_STORAGE_KEYS = {
   THEME: 'theme',
+  THRESHOLDDISPLAY: 'thresholdDisplay'
 } as const;
 
 export const DOM_ATTRIBUTES = {

--- a/frontend/src/app/services/global-settings.service/global-settings.service.ts
+++ b/frontend/src/app/services/global-settings.service/global-settings.service.ts
@@ -33,13 +33,18 @@ export class GlobalSettingsService {
 
   private initializeTheme(): void {
     const savedTheme = localStorage.getItem(LOCAL_STORAGE_KEYS.THEME);
+    const savedThresholdDisplay = localStorage.getItem(LOCAL_STORAGE_KEYS.THRESHOLDDISPLAY);
     this.darkMode = savedTheme === DARK_THEME;
+    if (savedThresholdDisplay != null) {
+      this.setThresholdDisplay(Number(savedThresholdDisplay) as ChartThresholdDisplay);
+    }
     this.applyTheme();
   }
 
   setThresholdDisplay(display: ChartThresholdDisplay): void {
     this.thresholdDisplay = display;
     this.thresholdDisplaySubject.next(display);
+    this.saveThresholdTheme();
   }
 
   toggleDarkMode(): void {
@@ -51,7 +56,12 @@ export class GlobalSettingsService {
     this.applyTheme();
     localStorage.setItem(LOCAL_STORAGE_KEYS.THEME, this.getThemeName());
   }
-
+  
+  private saveThresholdTheme() : void {
+    localStorage.setItem(LOCAL_STORAGE_KEYS.THRESHOLDDISPLAY, this.getThresholdDisplay().toLocaleString());
+  }
+  
+  
   applyTheme(): void {
     const themeName = this.getThemeName();
     const cssClass = this.darkMode ? CSS_CLASSES.DARK : CSS_CLASSES.LIGHT;
@@ -60,6 +70,10 @@ export class GlobalSettingsService {
     document.documentElement.setAttribute(DOM_ATTRIBUTES.CLASS, cssClass);
 
     this.themeSubject.next(themeName);
+  }
+
+  getThresholdDisplay(): ChartThresholdDisplay {
+    return this.thresholdDisplay;
   }
 
   getTheme(): boolean {


### PR DESCRIPTION
Issue #43 

La sauvegarde du mode d'affichage des graphiques se fait dans LocalStorage sous la forme d'un chiffre représantant un élément de l'enum ``ChartThresholdDisplay``

### Ajouts: 
* Dans ``constants.ts`` :
    * Constante ``THRESHOLDDISPLAY`` de type ``LOCAL_STORAGE_KEYS``
* Dans ``global-settings.service.ts`` :
    * Méthode ``saveThresholdTheme()`` --> Ajouter/Update la valeur sauvegardée dans LocalStorage
    * Fonction ``getThresholdDisplay()``