### PR TITLE
feat(backend api): added an OpenAPI documentation endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -324,3 +324,19 @@ async def post_random_measurements(
             db.add(db_Measurement)
             db.commit()
             db.refresh(db_Measurement)
+
+@app.get(
+    "/docs/openapi.json",
+    tags=["Docs"],
+    summary="OpenAPI JSON",
+    operation_id="openapi_json",
+)
+async def openapi_json():
+    """
+    Returns the OpenAPI JSON for the backend API.
+    """
+    try:
+        return app.openapi()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+


### PR DESCRIPTION
The endpoint returns the backend's own documentation in openapi.json format

This PR will enable [a script to externally update the Aquadash API documentation into AquaPedia](https://github.com/Aquapoly/wiki/pull/16), without depending on anything else inside Aquadash's source, nor even existing within it.