### PR TITLE
feat(units): added kelvin units for temperature sensor

### DIFF
--- a/frontend/src/app/components/line-chart/line-chart.component.ts
+++ b/frontend/src/app/components/line-chart/line-chart.component.ts
@@ -14,6 +14,9 @@ import {
 import { Measurement } from '@app/interfaces/measurement';
 import { HighchartsChartModule } from 'highcharts-angular';
 import * as Highcharts from 'highcharts';
+import { OnChanges, SimpleChanges } from '@angular/core';
+import { SensorUnitService } from '@app/services/sensor-unit.service';
+import { SensorDisplayUnit } from '@app/interfaces/sensor-unit';
 
 @Component({
   selector: 'app-line-chart',
@@ -21,7 +24,7 @@ import * as Highcharts from 'highcharts';
   templateUrl: './line-chart.component.html',
   styleUrl: './line-chart.component.scss',
 })
-export class LineChartComponent {
+export class LineChartComponent implements OnChanges {
   private themeSubscription!: Subscription;
   private thresholdDisplaySubscription!: Subscription;
   private thresholdDisplay: ChartThresholdDisplay =
@@ -37,10 +40,12 @@ export class LineChartComponent {
 
   @Input() sensor: Sensor = {} as Sensor;
   @Input() chartTitle: string = '';
+  @Input() displayUnit: SensorDisplayUnit | string = '';
 
   constructor(
     private readonly sensorService: SensorService,
-    private readonly globalSettings: GlobalSettingsService
+    private readonly globalSettings: GlobalSettingsService,
+    private readonly sensorUnitService: SensorUnitService,
   ) {}
 
   ngOnInit(): void {
@@ -67,10 +72,16 @@ export class LineChartComponent {
     }
   }
 
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['displayUnit'] && !changes['displayUnit'].firstChange) {
+      this.loadInitialData();
+    }
+  }
+
   private async loadInitialData() {
     const measurements = await this.sensorService.getSensorMeasurementsDelta(
       this.sensor.sensor_id,
-      this.sensorService.time_delta()
+      this.sensorService.time_delta(),
     );
 
     this.updateChartData(measurements);
@@ -80,9 +91,12 @@ export class LineChartComponent {
     const backgroundThresholdOn: boolean =
       this.thresholdDisplay === ChartThresholdDisplay.ColoredBackground ||
       this.thresholdDisplay === ChartThresholdDisplay.ColoredBackgroundWithLine;
+
     const zonesOn: boolean =
       this.thresholdDisplay === ChartThresholdDisplay.ColoredLine ||
       this.thresholdDisplay === ChartThresholdDisplay.ColoredBackgroundWithLine;
+
+    const displayedUnit = this.displayUnit || this.sensor.sensor_unit;
 
     this.chartOptions = {
       chart: {
@@ -109,13 +123,11 @@ export class LineChartComponent {
       },
       yAxis: {
         title: {
-          text: this.sensor.sensor_unit,
+          text: displayedUnit,
         },
         minorGridLineWidth: 0,
         gridLineWidth: 0,
-        plotBands: backgroundThresholdOn
-          ? this.createThresholds(this.sensor)
-          : [],
+        plotBands: backgroundThresholdOn ? this.createThresholds() : [],
         labels: {
           style: {
             color: THEME_COLOR[this.theme].baseContent + 'a0',
@@ -126,7 +138,7 @@ export class LineChartComponent {
         enabled: false,
       },
       tooltip: {
-        valueSuffix: this.sensor.sensor_unit,
+        valueSuffix: displayedUnit,
       },
       plotOptions: {
         spline: {
@@ -141,7 +153,6 @@ export class LineChartComponent {
           },
         },
       },
-
       series: [
         {
           type: 'line',
@@ -149,31 +160,33 @@ export class LineChartComponent {
           name: this.sensor.sensor_type,
           data: measurements.map((msr) => ({
             x: new Date(msr.timestamp).getTime(),
-            y: msr.value,
+            y: this.convertAndRoundValue(msr.value),
           })),
           lineWidth: 3,
           zones: zonesOn ? this.getZones() : [],
         },
       ],
     };
+
+    this.updateFlag = true;
   }
 
   private getZones(): Highcharts.SeriesZonesOptionsObject[] {
     return [
       {
-        value: this.sensor.threshold_critically_low,
+        value: this.convertAndRoundValue(this.sensor.threshold_critically_low),
         color: THEME_COLOR[this.theme].danger,
       },
       {
-        value: this.sensor.threshold_low,
+        value: this.convertAndRoundValue(this.sensor.threshold_low),
         color: THEME_COLOR[this.theme].warning,
       },
       {
-        value: this.sensor.threshold_high,
+        value: this.convertAndRoundValue(this.sensor.threshold_high),
         color: THEME_COLOR[this.theme].success,
       },
       {
-        value: this.sensor.threshold_critically_high,
+        value: this.convertAndRoundValue(this.sensor.threshold_critically_high),
         color: THEME_COLOR[this.theme].warning,
       },
       {
@@ -182,11 +195,22 @@ export class LineChartComponent {
     ];
   }
 
-  private createThresholds(sensor: Sensor): Highcharts.YAxisPlotBandsOptions[] {
+  private createThresholds(): Highcharts.YAxisPlotBandsOptions[] {
+    const criticallyLow = this.convertAndRoundValue(
+      this.sensor.threshold_critically_low,
+    );
+    const low = this.convertAndRoundValue(this.sensor.threshold_low);
+    const high = this.convertAndRoundValue(this.sensor.threshold_high);
+    const criticallyHigh = this.convertAndRoundValue(
+      this.sensor.threshold_critically_high,
+    );
+
+    const convertedMargin = this.getConvertedMargin();
+
     return [
       {
-        from: sensor.threshold_critically_low - THRESHOLD_MARGIN,
-        to: sensor.threshold_critically_low,
+        from: criticallyLow - convertedMargin,
+        to: criticallyLow,
         color:
           THEME_COLOR[this.theme].danger + ThresholdsBackgroundOpacity.Critical,
         label: {
@@ -197,8 +221,8 @@ export class LineChartComponent {
         },
       },
       {
-        from: sensor.threshold_critically_low,
-        to: sensor.threshold_low,
+        from: criticallyLow,
+        to: low,
         color:
           THEME_COLOR[this.theme].warning + ThresholdsBackgroundOpacity.Normal,
         label: {
@@ -209,8 +233,8 @@ export class LineChartComponent {
         },
       },
       {
-        from: sensor.threshold_low,
-        to: sensor.threshold_high,
+        from: low,
+        to: high,
         color:
           THEME_COLOR[this.theme].success + ThresholdsBackgroundOpacity.Normal,
         label: {
@@ -221,8 +245,8 @@ export class LineChartComponent {
         },
       },
       {
-        from: sensor.threshold_high,
-        to: sensor.threshold_critically_high,
+        from: high,
+        to: criticallyHigh,
         color:
           THEME_COLOR[this.theme].warning + ThresholdsBackgroundOpacity.Normal,
         label: {
@@ -233,8 +257,8 @@ export class LineChartComponent {
         },
       },
       {
-        from: sensor.threshold_critically_high,
-        to: sensor.threshold_critically_high + THRESHOLD_MARGIN,
+        from: criticallyHigh,
+        to: criticallyHigh + convertedMargin,
         color:
           THEME_COLOR[this.theme].danger + ThresholdsBackgroundOpacity.Critical,
         label: {
@@ -245,5 +269,30 @@ export class LineChartComponent {
         },
       },
     ];
+  }
+
+  private convertAndRoundValue(value: number): number {
+    const unitToDisplay = this.displayUnit || this.sensor.sensor_unit;
+
+    const convertedValue = this.sensorUnitService.convertSensorValue(
+      this.sensor,
+      value,
+      unitToDisplay,
+    );
+
+    return this.sensorUnitService.roundValue(convertedValue);
+  }
+
+  private getConvertedMargin(): number {
+    const displayedUnit = this.displayUnit || this.sensor.sensor_unit;
+
+    const convertedMargin = this.sensorUnitService.convertValue(
+      this.sensor.sensor_type,
+      this.sensor.sensor_unit,
+      displayedUnit,
+      THRESHOLD_MARGIN,
+    );
+
+    return this.sensorUnitService.roundValue(convertedMargin);
   }
 }

--- a/frontend/src/app/constants/constants.ts
+++ b/frontend/src/app/constants/constants.ts
@@ -206,16 +206,36 @@ export const API_ENDPOINTS = {
 export const SENSOR_UNIT_CONFIG: SensorUnitConfig = {
   [SensorType.temperature]: {
     defaultUnit: TemperatureUnit.Celsius,
-    availableUnits: [TemperatureUnit.Celsius, TemperatureUnit.Fahrenheit],
+    availableUnits: [
+      TemperatureUnit.Celsius,
+      TemperatureUnit.Fahrenheit,
+      TemperatureUnit.Kelvin,
+    ],
     conversions: {
       [TemperatureUnit.Celsius]: {
         [TemperatureUnit.Fahrenheit]: {
           convert: (value: number) => (value * 9) / 5 + 32,
         },
+        [TemperatureUnit.Kelvin]: {
+          convert: (value: number) => value + 273.15,
+        },
       },
+
       [TemperatureUnit.Fahrenheit]: {
         [TemperatureUnit.Celsius]: {
           convert: (value: number) => ((value - 32) * 5) / 9,
+        },
+        [TemperatureUnit.Kelvin]: {
+          convert: (value: number) => ((value - 32) * 5) / 9 + 273.15,
+        },
+      },
+
+      [TemperatureUnit.Kelvin]: {
+        [TemperatureUnit.Celsius]: {
+          convert: (value: number) => value - 273.15,
+        },
+        [TemperatureUnit.Fahrenheit]: {
+          convert: (value: number) => ((value - 273.15) * 9) / 5 + 32,
         },
       },
     },

--- a/frontend/src/app/constants/constants.ts
+++ b/frontend/src/app/constants/constants.ts
@@ -1,4 +1,9 @@
 import { SensorType } from '@app/interfaces/sensor-type';
+import {
+  EcUnit,
+  SensorUnitConfig,
+  TemperatureUnit,
+} from '@app/interfaces/sensor-unit';
 
 export const LIGHT_THEME: string = 'light';
 export const DARK_THEME: string = 'dracula';
@@ -101,7 +106,8 @@ export const MODAL_MESSAGES = {
   ERROR_TITLE: 'Erreur',
   ERROR_CONTENT:
     'Une erreur est survenue lors de la mise à jour des paramètres.',
-  ERROR_CONTENT_ADDED: 'Une erreur est survenue lors de l\'ajout du nouveau actuateur.',
+  ERROR_CONTENT_ADDED:
+    "Une erreur est survenue lors de l'ajout du nouveau actuateur.",
 } as const;
 
 export const API_DEFAULTS = {
@@ -137,7 +143,7 @@ export const SENSOR_VALIDITY_CLASSES = {
 export const LOCAL_STORAGE_KEYS = {
   THEME: 'theme',
   THRESHOLDDISPLAY: 'thresholdDisplay',
-  SENSOR_ORDER: 'sensor_order'
+  SENSOR_ORDER: 'sensor_order',
 } as const;
 
 export const DOM_ATTRIBUTES = {
@@ -196,3 +202,38 @@ export const API_ENDPOINTS = {
   SENSORS: 'sensors',
   LAST: 'last',
 } as const;
+
+export const SENSOR_UNIT_CONFIG: SensorUnitConfig = {
+  [SensorType.temperature]: {
+    defaultUnit: TemperatureUnit.Celsius,
+    availableUnits: [TemperatureUnit.Celsius, TemperatureUnit.Fahrenheit],
+    conversions: {
+      [TemperatureUnit.Celsius]: {
+        [TemperatureUnit.Fahrenheit]: {
+          convert: (value: number) => (value * 9) / 5 + 32,
+        },
+      },
+      [TemperatureUnit.Fahrenheit]: {
+        [TemperatureUnit.Celsius]: {
+          convert: (value: number) => ((value - 32) * 5) / 9,
+        },
+      },
+    },
+  },
+  [SensorType.ec]: {
+    defaultUnit: EcUnit.MilliSiemensPerCm,
+    availableUnits: [EcUnit.MilliSiemensPerCm, EcUnit.MicroSiemensPerCm],
+    conversions: {
+      [EcUnit.MilliSiemensPerCm]: {
+        [EcUnit.MicroSiemensPerCm]: {
+          factor: 1000,
+        },
+      },
+      [EcUnit.MicroSiemensPerCm]: {
+        [EcUnit.MilliSiemensPerCm]: {
+          factor: 0.001,
+        },
+      },
+    },
+  },
+};

--- a/frontend/src/app/interfaces/sensor-unit.ts
+++ b/frontend/src/app/interfaces/sensor-unit.ts
@@ -1,0 +1,34 @@
+import { SensorType } from './sensor-type';
+
+export enum TemperatureUnit {
+  Celsius = 'Celsius',
+  Fahrenheit = 'Fahrenheit',
+}
+
+export enum EcUnit {
+  MilliSiemensPerCm = 'mS/cm',
+  MicroSiemensPerCm = 'μS/cm',
+}
+
+export type SensorDisplayUnit = TemperatureUnit | EcUnit;
+
+export interface UnitConversionRule {
+  factor?: number;
+  convert?: (value: number) => number;
+}
+
+export type UnitConversionMap = {
+  [fromUnit: string]: {
+    [toUnit: string]: UnitConversionRule;
+  };
+};
+
+export interface SensorUnitDefinition {
+  defaultUnit: SensorDisplayUnit;
+  availableUnits: SensorDisplayUnit[];
+  conversions: UnitConversionMap;
+}
+
+export type SensorUnitConfig = Partial<
+  Record<SensorType, SensorUnitDefinition>
+>;

--- a/frontend/src/app/interfaces/sensor-unit.ts
+++ b/frontend/src/app/interfaces/sensor-unit.ts
@@ -3,6 +3,7 @@ import { SensorType } from './sensor-type';
 export enum TemperatureUnit {
   Celsius = 'Celsius',
   Fahrenheit = 'Fahrenheit',
+  Kelvin = 'Kelvin',
 }
 
 export enum EcUnit {

--- a/frontend/src/app/pages/status-page/status-page.component.html
+++ b/frontend/src/app/pages/status-page/status-page.component.html
@@ -5,13 +5,13 @@
     class="col-span-12 select w-full max-w-xs selectDiv"
   >
     @for (choice of chartChoices; track choice) {
-    <option [ngValue]="chartChoices.indexOf(choice)">{{ choice }}</option>
+      <option [ngValue]="chartChoices.indexOf(choice)">{{ choice }}</option>
     }
   </select>
   @if (sensors.length == 0) {
-  <div class="flex justify-center col-span-12">
-    <span class="loading loading-infinity loading-lg text-success"></span>
-  </div>
+    <div class="flex justify-center col-span-12">
+      <span class="loading loading-infinity loading-lg text-success"></span>
+    </div>
   }
   <div
     cdkDropList
@@ -19,54 +19,82 @@
     class="grid-cols-subgrid col-span-12 lg:col-span-12"
   >
     @for (sensor of sensors; track sensor.sensor_id) {
-    <div cdkDrag class="col-span-12 grid grid-cols-12">
-      <div class="col-span-12 lg:col-span-3 m-4">
-        <div class="stats shadow text-center bg-base-200 w-full h-full">
-          <div class="stat">
-            <div class="stat-title">{{ this.getSensorTitle(sensor) }}</div>
-            <div>
-              <div
-                [class]="[
-                  'text-' + this.getSensorValidity(sensor),
-                  'stat-value'
-                ]"
-                [id]="['sensor' + sensor.sensor_id]"
-              >
-                {{ this.getLastMeasurement(sensor) }}
+      <div cdkDrag class="col-span-12 grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-3 m-4">
+          <div class="stats shadow text-center bg-base-200 w-full h-full">
+            <div class="stat">
+              <div class="stat-title">{{ this.getSensorTitle(sensor) }}</div>
+              <div>
+                <div
+                  [class]="[
+                    'text-' + this.getSensorValidity(sensor),
+                    'stat-value',
+                  ]"
+                  [id]="['sensor' + sensor.sensor_id]"
+                >
+                  {{ this.getLastMeasurement(sensor) }}
+                </div>
+                <div class="stat-desc pt-3">
+                  @if (getAvailableUnits(sensor).length > 0) {
+                    <div class="flex justify-center mb-2">
+                      <select
+                        class="select select-sm"
+                        [ngModel]="getDisplayedUnit(sensor)"
+                        (ngModelChange)="
+                          onUnitChange(sensor.sensor_type, $event)
+                        "
+                      >
+                        @for (unit of getAvailableUnits(sensor); track unit) {
+                          <option [ngValue]="unit">{{ unit }}</option>
+                        }
+                      </select>
+                    </div>
+                  }
+                </div>
               </div>
-              <div class="stat-desc">{{ sensor.sensor_unit }}</div>
-            </div>
-            <div>
-              <div class="grid grid-cols-5">
-                <div class="cols-span-1 text-warning">
-                  {{ sensor.threshold_critically_low }}
-                </div>
-                <div class="cols-span-1 text-success">
-                  {{ sensor.threshold_low }}
-                </div>
-                <div class="cols-span-1"></div>
-                <div class="cols-span-1 text-success">
-                  {{ sensor.threshold_high }}
-                </div>
-                <div class="row-span-1 text-warning">
-                  {{ sensor.threshold_critically_high }}
+
+              <div>
+                <div class="grid grid-cols-5">
+                  <div class="cols-span-1 text-warning">
+                    {{
+                      getConvertedThreshold(
+                        sensor,
+                        sensor.threshold_critically_low
+                      )
+                    }}
+                  </div>
+                  <div class="cols-span-1 text-success">
+                    {{ getConvertedThreshold(sensor, sensor.threshold_low) }}
+                  </div>
+                  <div class="cols-span-1"></div>
+                  <div class="cols-span-1 text-success">
+                    {{ getConvertedThreshold(sensor, sensor.threshold_high) }}
+                  </div>
+                  <div class="row-span-1 text-warning">
+                    {{
+                      getConvertedThreshold(
+                        sensor,
+                        sensor.threshold_critically_high
+                      )
+                    }}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-      <div class="col-span-12 lg:col-span-9 m-4">
-        <div class="grid-cols-subgrid card shadow h-72 bg-base-200">
-          <app-line-chart
-            [chartTitle]="this.getSensorTitle(sensor)"
-            [sensor]="sensor"
-            class="h-full"
-          >
-          </app-line-chart>
+        <div class="col-span-12 lg:col-span-9 m-4">
+          <div class="grid-cols-subgrid card shadow h-72 bg-base-200">
+            <app-line-chart
+              [chartTitle]="this.getSensorTitle(sensor)"
+              [sensor]="sensor"
+              [displayUnit]="getDisplayedUnit(sensor)"
+              class="h-full"
+            >
+            </app-line-chart>
+          </div>
         </div>
       </div>
-    </div>
     }
   </div>
 </div>

--- a/frontend/src/app/pages/status-page/status-page.component.ts
+++ b/frontend/src/app/pages/status-page/status-page.component.ts
@@ -12,14 +12,28 @@ import {
 } from '@app/constants/constants';
 import { GlobalSettingsService } from '@app/services/global-settings.service/global-settings.service';
 import { LineChartComponent } from '@app/components/line-chart/line-chart.component';
-import {CdkDrag, CdkDragDrop, CdkDropList, moveItemInArray} from '@angular/cdk/drag-drop';
+import {
+  CdkDrag,
+  CdkDragDrop,
+  CdkDropList,
+  moveItemInArray,
+} from '@angular/cdk/drag-drop';
+import { SensorType } from '@app/interfaces/sensor-type';
+import { SensorDisplayUnit } from '@app/interfaces/sensor-unit';
+import { SensorUnitService } from '@app/services/sensor-unit.service';
 
 @Component({
   selector: 'app-status-page',
   standalone: true,
   templateUrl: './status-page.component.html',
   styleUrl: './status-page.component.scss',
-  imports: [LineChartComponent, FormsModule, CameraPictureComponent, CdkDrag, CdkDropList],
+  imports: [
+    LineChartComponent,
+    FormsModule,
+    CameraPictureComponent,
+    CdkDrag,
+    CdkDropList,
+  ],
 })
 export class StatusPageComponent implements OnInit {
   public sensors: Sensor[] = [];
@@ -28,10 +42,12 @@ export class StatusPageComponent implements OnInit {
   public chartSize: number = STATUS_PAGE_DEFAULTS.CHART_SIZE_INITIAL;
   selectedThresholdsDisplay: ChartThresholdDisplay =
     ChartThresholdDisplay.ColoredBackgroundWithLine;
+  public selectedUnits: Partial<Record<SensorType, SensorDisplayUnit>> = {};
 
   constructor(
     private readonly sensorService: SensorService,
-    private readonly globalSettings: GlobalSettingsService
+    private readonly globalSettings: GlobalSettingsService,
+    private readonly sensorUnitService: SensorUnitService,
   ) {}
 
   get chartChoices(): string[] {
@@ -47,7 +63,11 @@ export class StatusPageComponent implements OnInit {
 
   getLastMeasurement(sensor: Sensor): string {
     const measurement = this.findSensorMeasurement(sensor.sensor_id);
-    return measurement?.toString() ?? STATUS_PAGE_DEFAULTS.NO_DATA_MESSAGE;
+    if (measurement === undefined) {
+      return STATUS_PAGE_DEFAULTS.NO_DATA_MESSAGE;
+    }
+
+    return this.convertAndRoundValue(sensor, measurement).toString();
   }
 
   getSensorValidity(sensor: Sensor): string {
@@ -57,60 +77,74 @@ export class StatusPageComponent implements OnInit {
       return SENSOR_VALIDITY_CLASSES.NEUTRAL;
     }
 
-    if (this.isCriticalThreshold(measurement, sensor)) {
+    const convertedMeasurement = this.getConvertedMeasurement(sensor);
+
+    if (!convertedMeasurement) {
+      return SENSOR_VALIDITY_CLASSES.NEUTRAL;
+    }
+
+    if (this.isCriticalThreshold(convertedMeasurement, sensor)) {
       return SENSOR_VALIDITY_CLASSES.ERROR;
     }
 
-    if (this.isWarningThreshold(measurement, sensor)) {
+    if (this.isWarningThreshold(convertedMeasurement, sensor)) {
       return SENSOR_VALIDITY_CLASSES.WARNING;
     }
 
     return SENSOR_VALIDITY_CLASSES.SUCCESS;
   }
 
+  getAvailableUnits(sensor: Sensor): SensorDisplayUnit[] {
+    return this.sensorUnitService.getAvailableUnits(sensor.sensor_type);
+  }
+
   updateThresholdDisplay() {
     this.globalSettings.setThresholdDisplay(this.selectedThresholdsDisplay);
   }
 
-  protected drop(event: CdkDragDrop<any>){
+  protected drop(event: CdkDragDrop<any>) {
     moveItemInArray(this.sensors, event.previousIndex, event.currentIndex);
     this.globalSettings.saveSensorOrder(this.getSensorArray());
   }
 
-  private orderSensors():void{
+  private orderSensors(): void {
     const order: string[] = this.globalSettings.getSensorOrder();
-    this.sensors.sort( (a,b)=> {
+    this.sensors.sort((a, b) => {
       const indexA = order.indexOf(a.sensor_type);
       const indexB = order.indexOf(b.sensor_type);
-    
+
       const posA = indexA === -1 ? Number.MAX_SAFE_INTEGER : indexA;
       const posB = indexB === -1 ? Number.MAX_SAFE_INTEGER : indexB;
-    
+
       return posA - posB;
     });
   }
 
-  private getSensorArray():string[]{
+  private getSensorArray(): string[] {
     let order: string[] = [];
-    this.sensors.forEach(x => order.push(x.sensor_type));
+    this.sensors.forEach((x) => order.push(x.sensor_type));
     return order;
   }
 
   private isCriticalThreshold(measurement: number, sensor: Sensor): boolean {
     return (
-      measurement < sensor.threshold_critically_low ||
-      measurement > sensor.threshold_critically_high
+      measurement <
+        this.getConvertedThreshold(sensor, sensor.threshold_critically_low) ||
+      measurement >
+        this.getConvertedThreshold(sensor, sensor.threshold_critically_high)
     );
   }
 
   private isWarningThreshold(measurement: number, sensor: Sensor): boolean {
     return (
-      measurement < sensor.threshold_low || measurement > sensor.threshold_high
+      measurement < this.getConvertedThreshold(sensor, sensor.threshold_low) ||
+      measurement > this.getConvertedThreshold(sensor, sensor.threshold_high)
     );
   }
 
-    private async loadData() {
+  private async loadData() {
     this.sensors = await this.sensorService.getSensors();
+    this.initializeSelectedUnits();
     this.orderSensors();
     this.chartSize =
       STATUS_PAGE_DEFAULTS.CHART_SIZE_DIVISOR /
@@ -120,11 +154,57 @@ export class StatusPageComponent implements OnInit {
         const last_measurement: Measurement =
           await this.sensorService.getLastMeasurement(sensor.sensor_id);
         return [sensor.sensor_id, last_measurement?.value];
-      })
+      }),
     );
   }
 
   private findSensorMeasurement(sensorId: number): number | undefined {
     return this.sensorLastMeasurements.find((msr) => msr[0] === sensorId)?.[1];
+  }
+
+  onUnitChange(sensorType: SensorType, unit: SensorDisplayUnit): void {
+    this.selectedUnits[sensorType] = unit;
+  }
+
+  getConvertedThreshold(sensor: Sensor, threshold: number): number {
+    return this.convertAndRoundValue(sensor, threshold);
+  }
+
+  private initializeSelectedUnits(): void {
+    this.sensors.forEach((sensor) => {
+      if (!this.selectedUnits[sensor.sensor_type]) {
+        const defaultUnit = this.sensorUnitService.getDefaultUnit(
+          sensor.sensor_type,
+        );
+        if (defaultUnit) {
+          this.selectedUnits[sensor.sensor_type] = defaultUnit;
+        }
+      }
+    });
+  }
+
+  private getConvertedMeasurement(sensor: Sensor): number | undefined {
+    const measurement = this.findSensorMeasurement(sensor.sensor_id);
+
+    if (measurement === undefined) {
+      return undefined;
+    }
+
+    return this.convertAndRoundValue(sensor, measurement);
+  }
+
+  private convertAndRoundValue(sensor: Sensor, value: number): number {
+    const displayedUnit = this.getDisplayedUnit(sensor);
+    const convertedValue = this.sensorUnitService.convertSensorValue(
+      sensor,
+      value,
+      displayedUnit,
+    );
+
+    return this.sensorUnitService.roundValue(convertedValue);
+  }
+
+  getDisplayedUnit(sensor: Sensor): string {
+    return this.selectedUnits[sensor.sensor_type] ?? sensor.sensor_unit;
   }
 }

--- a/frontend/src/app/services/sensor-unit.service.ts
+++ b/frontend/src/app/services/sensor-unit.service.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@angular/core';
+import { Sensor } from '@app/interfaces/sensor';
+import { SensorType } from '@app/interfaces/sensor-type';
+import {
+  SensorDisplayUnit,
+  SensorUnitDefinition,
+  UnitConversionRule,
+} from '@app/interfaces/sensor-unit';
+import { SENSOR_UNIT_CONFIG } from '@app/constants/constants';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SensorUnitService {
+  getUnitDefinition(sensorType: SensorType): SensorUnitDefinition | undefined {
+    return SENSOR_UNIT_CONFIG[sensorType];
+  }
+
+  getAvailableUnits(sensorType: SensorType): SensorDisplayUnit[] {
+    return this.getUnitDefinition(sensorType)?.availableUnits ?? [];
+  }
+
+  getDefaultUnit(sensorType: SensorType): SensorDisplayUnit | undefined {
+    return this.getUnitDefinition(sensorType)?.defaultUnit;
+  }
+
+  convertValue(
+    sensorType: SensorType,
+    fromUnit: string,
+    toUnit: string,
+    value: number,
+  ): number {
+    if (fromUnit === toUnit) {
+      return value;
+    }
+
+    const rule = this.getConversionRule(sensorType, fromUnit, toUnit);
+
+    if (!rule) {
+      return value;
+    }
+
+    if (rule.factor !== undefined) {
+      return value * rule.factor;
+    }
+
+    if (rule.convert) {
+      return rule.convert(value);
+    }
+
+    return value;
+  }
+
+  convertSensorValue(
+    sensor: Sensor,
+    value: number,
+    displayUnit: string,
+  ): number {
+    return this.convertValue(
+      sensor.sensor_type,
+      sensor.sensor_unit,
+      displayUnit,
+      value,
+    );
+  }
+
+  roundValue(value: number, decimals = 2): number {
+    return Number(value.toFixed(decimals));
+  }
+
+  private getConversionRule(
+    sensorType: SensorType,
+    fromUnit: string,
+    toUnit: string,
+  ): UnitConversionRule | undefined {
+    return this.getUnitDefinition(sensorType)?.conversions[fromUnit]?.[toUnit];
+  }
+}


### PR DESCRIPTION
**Description**
The EC and temperature sensors have a select component with different units available.

**So far :**
Temperature has : F, C and K
EC has mS/cm and μS/cm

**To add a new unit :**
- Add the unit in the sensor's enum in sensor-unit.ts interface 
- Add the new unit's config to SENSOR_UNIT_CONFIG located in the constants.ts file (add the conversion formulas essentially)

**If we add new sensors, what happens?**
- If you want the new sensor to have different units : add its config in SENSOR_UNIT_CONFIG 
Because :
if a sensor type exists in SENSOR_UNIT_CONFIG -> show unit options and allow conversion
if it does not exist there -> do nothing special, use raw value

<img width="2360" height="1006" alt="Screenshot 2026-03-08 163824" src="https://github.com/user-attachments/assets/25383584-8f4b-4d78-b6ec-aeddc1ed1152" />
