### PR TITLE
Ajout de contrainte sur les colonnes de threshold d'un sensor

### DIFF
--- a/backend/alembic/versions/b99bff401293_constraints_on_threshold_values.py
+++ b/backend/alembic/versions/b99bff401293_constraints_on_threshold_values.py
@@ -21,12 +21,9 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     """Upgrade schema."""
     op.create_check_constraint("check_threshold_values", "sensors", 
-            "(threshold_critically_low <= threshold_low AND "
+            "threshold_critically_low <= threshold_low AND "
             "threshold_low <= threshold_high AND "
-            "threshold_high <= threshold_critically_high) OR "
-            "(threshold_critically_low >= threshold_low AND "
-            "threshold_low >= threshold_high AND "
-            "threshold_high >= threshold_critically_high)")
+            "threshold_high <= threshold_critically_high")
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/b99bff401293_constraints_on_threshold_values.py
+++ b/backend/alembic/versions/b99bff401293_constraints_on_threshold_values.py
@@ -1,0 +1,34 @@
+"""Constraints on threshold values
+
+Revision ID: b99bff401293
+Revises: 8975582390c7
+Create Date: 2026-03-13 22:05:31.580716
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b99bff401293'
+down_revision: Union[str, Sequence[str], None] = '8975582390c7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_check_constraint("check_threshold_values", "sensors", 
+            "(threshold_critically_low <= threshold_low AND "
+            "threshold_low <= threshold_high AND "
+            "threshold_high <= threshold_critically_high) OR "
+            "(threshold_critically_low >= threshold_low AND "
+            "threshold_low >= threshold_high AND "
+            "threshold_high >= threshold_critically_high)")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint("check_threshold_values", "sensors", type_="check")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -48,12 +48,9 @@ class Sensor(Base):
     __table_args__ = (
         CheckConstraint("sensor_id>=0", name="check_id_sensor_positive"),
         CheckConstraint(
-            "(threshold_critically_low <= threshold_low AND "
+            "threshold_critically_low <= threshold_low AND "
             "threshold_low <= threshold_high AND "
-            "threshold_high <= threshold_critically_high) OR "
-            "(threshold_critically_low >= threshold_low AND "
-            "threshold_low >= threshold_high AND "
-            "threshold_high >= threshold_critically_high)",
+            "threshold_high <= threshold_critically_high",
             name="check_threshold_values"
         ),
     )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -47,6 +47,15 @@ class Sensor(Base):
 
     __table_args__ = (
         CheckConstraint("sensor_id>=0", name="check_id_sensor_positive"),
+        CheckConstraint(
+            "(threshold_critically_low <= threshold_low AND "
+            "threshold_low <= threshold_high AND "
+            "threshold_high <= threshold_critically_high) OR "
+            "(threshold_critically_low >= threshold_low AND "
+            "threshold_low >= threshold_high AND "
+            "threshold_high >= threshold_critically_high)",
+            name="check_threshold_values"
+        ),
     )
 
 


### PR DESCRIPTION
# Ajout de contrainte sur le threshold

On pouvait avoir les threshold dans tous les sens, donc j'ai réglé ça pour que ça soit en ordre décroissant ou en ordre croissant.

## Changements

- Fichier de migration de DB
- Ajout de la contrainte dans le modèle de Sensor



PS: Ça me dit que Copilot va review pis je peux pas l'enlever