### PR TITLE
feat: Enfin ajouté un endpoint pour supprimer une mesure

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -256,6 +256,22 @@ def post_measurement(db: Session, measurement: schemas.MeasurementBase):
     return result
 
 
+def delete_measurement(db: Session, measurement_id: int):
+    """
+    Deletes the measurement with the given id.
+    Args:
+        db (Session): SQLAlchemy session.
+        measurement_id (int): The ID of the measurement to delete.
+    Raises:
+        HTTPException: Code 404 if the measurement doesn't exist.
+    """
+    measurement = db.get(models.Measurement, measurement_id)
+    if measurement is None:
+        raise HTTPException(status_code=404, detail="Measurement not found")
+    db.delete(measurement)
+    db.commit()
+
+
 def post_user(db: Session, username: str, password: str):
     """
     Creates and inserts a new user into the database.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -222,6 +222,17 @@ async def get_last_measurement(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sensor ID has no measurements.")
     return result
 
+
+@app.delete(
+        "/measurements/{measurement_id}",
+        tags=["Measurements"],
+)
+async def delete_measurement(
+    measurement_id: int, db: Session = Depends(get_db)
+):
+    return crud.delete_measurement(db, measurement_id)
+
+
 @app.get(
     "/actuators/{prototype_id}",
     tags=["Actuators"],


### PR DESCRIPTION
### Woohoo, on peut supprimer un Measurement! 

#### Changements:
- endpoint DELETE /measurements/{measurement_id)
- fonction delete_measurement dans CRUD


closes #91 