### PR TITLE
Feature/automate documentation

### DIFF
--- a/.github/workflows/api-doc-gen.yml
+++ b/.github/workflows/api-doc-gen.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout Aquadash
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: aquadash
 
@@ -39,7 +39,7 @@ jobs:
           curl -fsS http://localhost:8000/docs/openapi.json > /dev/null
 
       - name: Checkout Aquapedia
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: Aquapoly/aquapedia
           path: aquapedia

--- a/.github/workflows/api-doc-gen.yml
+++ b/.github/workflows/api-doc-gen.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Wiki health check
         run: |
-          HTTP_CODE=$(curl -L --max-time 15 -fsS -o /dev/null -w "%{http_code}" http://wiki.aquapoly.ca)
+          HTTP_CODE=$(curl -L --max-time 15 -sS -o /dev/null -w "%{http_code}" http://wiki.aquapoly.ca)
           echo "Wiki health check: HTTP $HTTP_CODE"
 
           echo "## Wiki Health Check" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/api-doc-gen.yml
+++ b/.github/workflows/api-doc-gen.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Update API documentation on the wiki
         working-directory: aquapedia/api-doc-gen
         run: |
-          if ! curl -fsS -o /dev/null -w "%{http_code}" http://wiki.aquapoly.ca | grep -q "200\|301\|302"; then 
+          if ! { curl --max-time 30 -fsS -o /dev/null -w "%{http_code}" http://wiki.aquapoly.ca | grep -q "200\|301\|302"; }; then 
             echo "::warning::Wiki (wiki.aquapoly.ca) is not reachable. API documentation was not updated."
             echo "## Wiki Unreachable" >> $GITHUB_STEP_SUMMARY
             echo "The wiki at http://wiki.aquapoly.ca is currently down or unreachable." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/api-doc-gen.yml
+++ b/.github/workflows/api-doc-gen.yml
@@ -1,0 +1,49 @@
+name: Generate Aquadash API Docs
+
+on:
+  push:
+    tags:
+      - '*release*'
+
+permissions:
+  contents: write
+
+jobs:
+  api-doc-gen:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Start Aquadash backend (docker-compose)
+        working-directory: backend
+        run: |
+          docker compose up -d --build
+          echo "Waiting for OpenAPI endpoint. Max timeout 2 minutes"
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:8000/docs/openapi.json > /dev/null; then
+              echo "Backend running"
+              break
+            fi
+            sleep 2
+          done
+          curl -fsS http://localhost:8000/docs/openapi.json > /dev/null
+
+      - name: Generate OpenAPI JSON
+        run: |
+          curl -fsS http://localhost:8000/docs/openapi.json -o aquadash-openapi.json
+          echo "OpenAPI JSON generated successfully"
+          cat aquadash-openapi.json | jq '.' > /dev/null || (echo "Invalid JSON" && exit 1)
+
+      - name: Tear down backend
+        working-directory: backend
+        if: always()
+        run: docker compose down
+
+      - name: Upload to Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: aquadash-openapi.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/api-doc-gen.yml
+++ b/.github/workflows/api-doc-gen.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Wiki health check
         run: |
           if ! { curl --max-time 15 -fsS -o /dev/null -w "%{http_code}" http://wiki.aquapoly.ca | grep -q "200\|301\|302"; }; then 
-            echo "::error::Wiki (wiki.aquapoly.ca) is not reachable. API documentation was not updated."
+            echo "::error title=Wiki health check failed::wiki.aquapoly.ca not reachable. API documentation was not updated."
             echo "## Wiki Unreachable" >> $GITHUB_STEP_SUMMARY
             echo "The wiki at http://wiki.aquapoly.ca is currently down or unreachable." >> $GITHUB_STEP_SUMMARY
             echo "API documentation was not updated." >> $GITHUB_STEP_SUMMARY
@@ -51,7 +51,7 @@ jobs:
             fi
             sleep 2
           done
-          
+
           curl -fsS http://localhost:8000/docs/openapi.json > /dev/null
 
           echo "started=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/api-doc-gen.yml
+++ b/.github/workflows/api-doc-gen.yml
@@ -61,7 +61,6 @@ jobs:
           cat > .env << EOF
           AQUAPEDIA_API_KEY=${{ secrets.AQUAPEDIA_API_TOKEN }}
           AQUAPEDIA_URL=http://wiki.aquapoly.ca
-          BASE_PATH=Poles/Informatique
           LOCALE=fr
           EOF
 
@@ -69,7 +68,7 @@ jobs:
           source .venv/bin/activate
           pip install -r requirements.txt
 
-          python docgen.py --url http://localhost:8000/docs/openapi.json --app-name aquadash --output ./output --sync
+          python docgen.py --url http://localhost:8000/docs/openapi.json --app-path poleinfo/aquadash --output ./output --sync
 
       - name: Tear down backend
         working-directory: aquadash/backend

--- a/.github/workflows/api-doc-gen.yml
+++ b/.github/workflows/api-doc-gen.yml
@@ -13,6 +13,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Wiki health check
+        run: |
+          if ! { curl --max-time 15 -fsS -o /dev/null -w "%{http_code}" http://wiki.aquapoly.ca | grep -q "200\|301\|302"; }; then 
+            echo "::error::Wiki (wiki.aquapoly.ca) is not reachable. API documentation was not updated."
+            echo "## Wiki Unreachable" >> $GITHUB_STEP_SUMMARY
+            echo "The wiki at http://wiki.aquapoly.ca is currently down or unreachable." >> $GITHUB_STEP_SUMMARY
+            echo "API documentation was not updated." >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
       - name: Checkout Aquadash
         uses: actions/checkout@v6
         with:
@@ -48,14 +58,6 @@ jobs:
       - name: Update API documentation on the wiki
         working-directory: aquapedia/api-doc-gen
         run: |
-          if ! { curl --max-time 30 -fsS -o /dev/null -w "%{http_code}" http://wiki.aquapoly.ca | grep -q "200\|301\|302"; }; then 
-            echo "::warning::Wiki (wiki.aquapoly.ca) is not reachable. API documentation was not updated."
-            echo "## Wiki Unreachable" >> $GITHUB_STEP_SUMMARY
-            echo "The wiki at http://wiki.aquapoly.ca is currently down or unreachable." >> $GITHUB_STEP_SUMMARY
-            echo "API documentation was not updated." >> $GITHUB_STEP_SUMMARY
-            exit 0
-          fi
-
           cat > .env << EOF
           AQUAPEDIA_API_KEY=${{ secrets.AQUAPEDIA_API_TOKEN }}
           AQUAPEDIA_URL=http://wiki.aquapoly.ca

--- a/.github/workflows/api-doc-gen.yml
+++ b/.github/workflows/api-doc-gen.yml
@@ -29,16 +29,21 @@ jobs:
           path: aquadash
 
       - name: Start Aquadash database (backend dependency)
+        id: containers_database
         working-directory: aquadash/backend
         run: |
           docker compose up -d db
           sleep 10
 
+          echo "started=true" >> $GITHUB_OUTPUT
+
       - name: Start Aquadash backend
+        id: containers_backend
         working-directory: aquadash/backend
         run: |
           docker compose up -d --build app
           echo "Waiting for OpenAPI endpoint. Max timeout 2 minutes"
+
           for i in $(seq 1 60); do
             if curl -fsS http://localhost:8000/docs/openapi.json > /dev/null; then
               echo "Backend running"
@@ -46,7 +51,10 @@ jobs:
             fi
             sleep 2
           done
+          
           curl -fsS http://localhost:8000/docs/openapi.json > /dev/null
+
+          echo "started=true" >> $GITHUB_OUTPUT
 
       - name: Checkout Aquapedia
         uses: actions/checkout@v6
@@ -72,5 +80,5 @@ jobs:
 
       - name: Tear down backend
         working-directory: aquadash/backend
-        if: always()
+        if: steps.containers_database.started == 'true' || steps.containers_backend.started == 'true'
         run: docker compose down

--- a/.github/workflows/api-doc-gen.yml
+++ b/.github/workflows/api-doc-gen.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Wiki health check
         run: |
-          HTTP_CODE=$(curl --max-time 15 -fsS -o /dev/null -w "%{http_code}" http://wiki.aquapoly.ca)
+          HTTP_CODE=$(curl -L --max-time 15 -fsS -o /dev/null -w "%{http_code}" http://wiki.aquapoly.ca)
           echo "Wiki health check: HTTP $HTTP_CODE"
 
           echo "## Wiki Health Check" >> $GITHUB_STEP_SUMMARY
@@ -23,7 +23,7 @@ jobs:
           echo "- **HTTP status code**: $HTTP_CODE" >> $GITHUB_STEP_SUMMARY
           echo "- **Timestamp**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
 
-          if ! echo "$HTTP_CODE" | grep -q "200\|301\|302"; then 
+          if ! echo "$HTTP_CODE" | grep -q "200"; then 
             echo "::error title=Wiki health check failed::wiki.aquapoly.ca not reachable. API documentation was not updated."
             echo "Health check failed." >> $GITHUB_STEP_SUMMARY
             echo "The wiki at http://wiki.aquapoly.ca is currently down or unreachable." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/api-doc-gen.yml
+++ b/.github/workflows/api-doc-gen.yml
@@ -13,17 +13,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout Aquadash
         uses: actions/checkout@v4
+        with:
+          path: aquadash
 
       - name: Start Aquadash database (backend dependency)
-        working-directory: backend
+        working-directory: aquadash/backend
         run: |
           docker compose up -d db
           sleep 10
 
       - name: Start Aquadash backend
-        working-directory: backend
+        working-directory: aquadash/backend
         run: |
           docker compose up -d --build app
           echo "Waiting for OpenAPI endpoint. Max timeout 2 minutes"
@@ -36,20 +38,30 @@ jobs:
           done
           curl -fsS http://localhost:8000/docs/openapi.json > /dev/null
 
-      - name: Generate OpenAPI JSON
+      - name: Checkout Aquapedia
+        uses: actions/checkout@v4
+        with:
+          repository: Aquapoly/aquapedia
+          path: aquapedia
+          token: ${{ secrets.AQUAPEDIA_READ_TOKEN }}
+
+      - name: Update API documentation on the wiki
+        working-directory: aquapedia/api-doc-gen
         run: |
-          curl -fsS http://localhost:8000/docs/openapi.json -o aquadash-openapi.json
-          echo "OpenAPI JSON generated successfully"
-          cat aquadash-openapi.json | jq '.' > /dev/null || (echo "Invalid JSON" && exit 1)
+          cat > .env << EOF
+          AQUAPEDIA_API_KEY=${{ secrets.AQUAPEDIA_API_TOKEN }}
+          AQUAPEDIA_URL=http://wiki.aquapoly.ca
+          BASE_PATH=Poles/Informatique
+          LOCALE=fr
+          EOF
+
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install -r requirements.txt
+
+          python docgen.py --url http://localhost:8000/docs/openapi.json --app-name aquadash --output ./output --sync
 
       - name: Tear down backend
         working-directory: backend
         if: always()
         run: docker compose down
-
-      - name: Upload to Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: aquadash-openapi.json
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/api-doc-gen.yml
+++ b/.github/workflows/api-doc-gen.yml
@@ -48,6 +48,14 @@ jobs:
       - name: Update API documentation on the wiki
         working-directory: aquapedia/api-doc-gen
         run: |
+          if ! curl -fsS -o /dev/null -w "%{http_code}" http://wiki.aquapoly.ca | grep -q "200\|301\|302"; then 
+            echo "::warning::Wiki (wiki.aquapoly.ca) is not reachable. API documentation was not updated."
+            echo "## Wiki Unreachable" >> $GITHUB_STEP_SUMMARY
+            echo "The wiki at http://wiki.aquapoly.ca is currently down or unreachable." >> $GITHUB_STEP_SUMMARY
+            echo "API documentation was not updated." >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
           cat > .env << EOF
           AQUAPEDIA_API_KEY=${{ secrets.AQUAPEDIA_API_TOKEN }}
           AQUAPEDIA_URL=http://wiki.aquapoly.ca
@@ -62,6 +70,6 @@ jobs:
           python docgen.py --url http://localhost:8000/docs/openapi.json --app-name aquadash --output ./output --sync
 
       - name: Tear down backend
-        working-directory: backend
+        working-directory: aquadash/backend
         if: always()
         run: docker compose down

--- a/.github/workflows/api-doc-gen.yml
+++ b/.github/workflows/api-doc-gen.yml
@@ -15,12 +15,22 @@ jobs:
     steps:
       - name: Wiki health check
         run: |
-          if ! { curl --max-time 15 -fsS -o /dev/null -w "%{http_code}" http://wiki.aquapoly.ca | grep -q "200\|301\|302"; }; then 
+          HTTP_CODE=$(curl --max-time 15 -fsS -o /dev/null -w "%{http_code}" http://wiki.aquapoly.ca)
+          echo "Wiki health check: HTTP $HTTP_CODE"
+
+          echo "## Wiki Health Check" >> $GITHUB_STEP_SUMMARY
+          echo "- **URL**: http://wiki.aquapoly.ca" >> $GITHUB_STEP_SUMMARY
+          echo "- **HTTP status code**: $HTTP_CODE" >> $GITHUB_STEP_SUMMARY
+          echo "- **Timestamp**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
+
+          if ! echo "$HTTP_CODE" | grep -q "200\|301\|302"; then 
             echo "::error title=Wiki health check failed::wiki.aquapoly.ca not reachable. API documentation was not updated."
-            echo "## Wiki Unreachable" >> $GITHUB_STEP_SUMMARY
+            echo "Health check failed." >> $GITHUB_STEP_SUMMARY
             echo "The wiki at http://wiki.aquapoly.ca is currently down or unreachable." >> $GITHUB_STEP_SUMMARY
             echo "API documentation was not updated." >> $GITHUB_STEP_SUMMARY
             exit 1
+          else
+            echo "Health check passed." >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Checkout Aquadash

--- a/.github/workflows/api-doc-gen.yml
+++ b/.github/workflows/api-doc-gen.yml
@@ -16,10 +16,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Start Aquadash backend (docker-compose)
+      - name: Start Aquadash database (backend dependency)
         working-directory: backend
         run: |
-          docker compose up -d --build
+          docker compose up -d db
+          sleep 10
+
+      - name: Start Aquadash backend
+        working-directory: backend
+        run: |
+          docker compose up -d --build app
           echo "Waiting for OpenAPI endpoint. Max timeout 2 minutes"
           for i in $(seq 1 60); do
             if curl -fsS http://localhost:8000/docs/openapi.json > /dev/null; then


### PR DESCRIPTION
Documentation on the Aquapedia wiki is now automatically updated via Github actions.
Tagging a commit with the word *release* now triggers Thierry's api-doc-gen scripts.

## Workflow Steps
### 1: Wiki Health Check
The workflow attempts to ping the Aquapedia server in order to establish the server's health.

### 2: Checkout Aquadash
The workflow makes a local copy of Aquadash

### 3: Start Aquadash Database
The workflow starts the Aquadash database

### 4: Start Aquadash Backend
The workflow starts the Aquadash backend

### 5: Checkout Aquapedia
The workflow makes a local copy of Aquapedia (for the scripts)

### 6: Update API Documentation
The script is executed

### 7: Backend Teardown
We compose down the backend